### PR TITLE
Formatting method for whole-second precision

### DIFF
--- a/src/Data/Time/ISO8601.hs
+++ b/src/Data/Time/ISO8601.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 module Data.Time.ISO8601
   ( formatISO8601
+  , formatISO8601Seconds
   , formatISO8601Millis
   , formatISO8601Micros
   , formatISO8601Nanos
@@ -36,6 +37,14 @@ formatPadded t
   | otherwise        = str ++ "000000000000"
   where
     str = formatTime defaultTimeLocale "%FT%T%Q" t
+
+
+-- | Formats a time in ISO 8601 with up to second precision
+-- The format is precisely:
+--
+-- >YYYY-MM-DDTHH:mm:ssZ
+formatISO8601Seconds :: UTCTime -> String
+formatISO8601Seconds t = formatTime defaultTimeLocale "%FT%TZ" t
 
 
 -- | Formats a time in ISO 8601 with up to millisecond precision and trailing zeros.


### PR DESCRIPTION
I would like to do `getCurrentTime >>= putStrLn . formatISO8601Seconds` (or similar) and get nice output (e.g. suitable for decorating logs). Suggestions are welcome.
